### PR TITLE
Remove hard-coded width for field labels

### DIFF
--- a/snippets/presentation.php
+++ b/snippets/presentation.php
@@ -15,7 +15,7 @@
 			<?php if(isset($first['labels']) && !empty($first['labels'])) : ?>
 				<div class="egr-labels"><?php
 					foreach($first['labels'] as $field_key => $field) :
-						?><div data-prefix="_i3_egr__" data-field-name="text" class="field egr-field field-grid-item field-grid-item-1-2 field-name-text_i3_egr__">
+						?><div data-prefix="_i3_egr__" data-field-name="text" class="field egr-field field-grid-item field-grid-item-<?php echo (isset($field['width']) ? str_replace('/', '-', $field['width']) : '1-2') ?> field-name-text_i3_egr__">
 							<label class="label" data-for="form-field-text_i3_egr__"><?php echo $field['label']; ?></label>
 						</div><?php endforeach;
 				?>


### PR DESCRIPTION
Field labels had a hard coded width of 1/2. Now uses the method Kirby does for it's base fields.

I left the 1/2 in there as a fall back in case the field doesn't specify a width. This should prevent breaking old layouts.